### PR TITLE
Ĝisdatigis por uzi novan eraroprizorganton kaj uzi la novan version de la servilo

### DIFF
--- a/unua_testo.py
+++ b/unua_testo.py
@@ -1,9 +1,9 @@
 from miavortaro import MiaVortaro
 
-miavortaro = MiaVortaro()
-miavortaro.komencu()
-vortoj = miavortaro.listigiVortojn()
-print(vortoj)
-rezulto = miavortaro.serĉiVorton("en")
-print(rezulto)
-miavortaro.ĉesu()
+with MiaVortaro() as miavortaro:
+    miavortaro.komencu()
+    vortoj = miavortaro.listigiVortojn()
+    print(vortoj)
+    rezulto = miavortaro.serĉiVorton("en")
+    print(rezulto)
+    miavortaro.ĉesu()

--- a/ŝanĝnoto.md
+++ b/ŝanĝnoto.md
@@ -1,0 +1,6 @@
+# Ŝanĝnoto
+Jen la ŝanĝoj de miavortaro-py 0.2-alpha
+
+1. Aldonis `__enter__` kaj `__exit__` al MiaVortaro klazo por ke oni povas uzi `with` blokojn
+2. Aldonis `EraroPrizorganto` klazo por prizorgi la kompleksajn erarojn, speciale prizorgi la erarojn de `requests` (ne ankoraŭ finigita)
+3. Ŝanĝis `listigiVortojn` por uzi `tranĉi` parametro anstataŭ `listo`, laŭ la nova versio de MiaVortaro-servilo


### PR DESCRIPTION
1. `EraroPrizorganto`-n aldonis kaj uzis nune
2. Aldonis pliajn esceptojn sendante la petojn
3. Ŝanĝis la `listigiVortojn`-peton por uzi la `tranĉi` parametro anstataŭ la `listo`, laŭ la nova versio de la servilo 